### PR TITLE
Fixes failures in 5.12 and 5.14.

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -13,6 +13,7 @@ my $build = Module::Build->new(
     },
     build_requires => {
         'Fennec' => '1.012',
+        'ExtUtils::ParseXS' => '3.15',
     },
 );
 


### PR DESCRIPTION
This version of ExtUtils::ParseXS (actually 3.13_01) introduced
improved typemap parsing.

This fixes failures on 5.12 and 5.14.
